### PR TITLE
Include cache-control headers in nginx.conf

### DIFF
--- a/app-nginx.conf.sigil
+++ b/app-nginx.conf.sigil
@@ -1,0 +1,39 @@
+worker_processes 1;
+error_log stderr;
+pid nginx.pid;
+daemon off;
+
+events {
+  worker_connections 768;
+}
+
+http {
+  types_hash_max_size 2048;
+  include mime.types;
+
+  server {
+    listen {{ $.PORT }};
+    server_name  _;
+    {{ if ne $.NGINX_ROOT "" }}
+      root /app/www/{{ $.NGINX_ROOT }};
+    {{ else }}
+      root /app/www;
+    {{ end }}
+
+    index index.html;
+
+    location ~ ^/(images|javascript|js|css|flash|media|static)/  {
+      {{ if ne $.NGINX_ROOT "" }}
+        root /app/www/{{ $.NGINX_ROOT }};
+      {{ else }}
+        root /app/www;
+      {{ end }}
+      expires 60;
+    }
+
+    location / {
+      try_files $uri $uri/ /index.html;
+      expires 60;
+    }
+  }
+}


### PR DESCRIPTION
This commit adds app-nginx.conf.sigil, which the buildpack specified in .env uses to generate config for nginx. It sets expiration to every 60 seconds.